### PR TITLE
fix: settle successful restricted SMS sends

### DIFF
--- a/docs/issues/345/android-17-restricted-sms-report.md
+++ b/docs/issues/345/android-17-restricted-sms-report.md
@@ -1,0 +1,134 @@
+# Successful browser SMS remains stuck on “Sending…” on Android 17
+
+## Tracking
+
+- Issue: https://github.com/plainhub/plain-app/issues/345
+- Repositories: https://github.com/plainhub/plain-app and https://github.com/plainhub/plain-desktop
+- Branch/commit tested: `plain-app` `4ae019ba` (`v3.3.16`, current upstream); `plain-desktop` `d3b1ff1e` (current upstream)
+- Pull request: to be added after creation
+
+## Priority and scope
+
+This is a high-priority SMS correctness bug because the browser reports an in-progress send indefinitely even after Android confirms that the carrier send succeeded. It affects the browser UI and the shared Tauri desktop frontend when the Android host applies Android 17's restricted-message behavior to SMS sent by a non-default messaging app.
+
+The correction is intentionally limited to truthful terminal status for a correlated browser send while retaining the optimistic item for later provider reconciliation. It does not bypass Android's restricted-message access control, make PlainApp the default SMS application, or attempt to replace Android's system SMS database.
+
+## Reported behavior
+
+After upgrading the Android app to PlainApp 3.3.16, an SMS sent from an open browser conversation remains labeled “Sending…” forever. Waiting and switching threads do not settle the status.
+
+## Reproduction
+
+### Environment
+
+- Android host: PlainApp 3.3.16, which is current upstream commit `4ae019ba`
+- Device: Pixel 9 Pro running GrapheneOS on Android 17 / API 37
+- Browser: Chrome 151 using the PlainApp web client bundled with 3.3.16
+- Permissions: PlainApp's read-SMS and send-SMS access enabled and granted
+- Default SMS application: a separate native messaging application; PlainApp is not the default SMS application
+
+### Steps
+
+1. Open an existing SMS conversation in the PlainApp browser client.
+2. Send an SMS to an authorized test destination.
+3. Observe the optimistic outgoing bubble.
+4. Wait for the Android sent callback and the browser's provider reconciliation retries.
+
+### Actual result
+
+- The GraphQL `sendSms` mutation returns `true` without errors.
+- The browser receives a correlated `SMS_SEND_RESULT` WebSocket event with `success=true` and Android's successful result code.
+- Android persists a sent SMS row with successful provider status/error fields.
+- PlainApp's GraphQL SMS query cannot return that row.
+- The optimistic bubble remains and continues to display “Sending…” after every retry and after the normal five-minute deadline would have elapsed.
+
+### Expected result
+
+Once the correlated Android sent callback reports success, the outgoing bubble should display “Sent”. It should remain eligible for replacement by the authoritative provider row if that row later becomes readable.
+
+## Investigation findings
+
+### The carrier send succeeds
+
+The failure is not a GraphQL timeout, WebSocket disconnect, missing Android permission, SIM selection failure, or carrier failure. The mutation succeeds, Android invokes PlainApp's sent `PendingIntent`, the result tracker publishes a correlated successful terminal event, and the system SMS provider contains the sent row.
+
+### Android 17 hides the persisted row from PlainApp
+
+Safe provider metadata comparison showed that ordinary incoming messages and messages sent by the default SMS application have `restricted=0`. Every controlled message sent by PlainApp has:
+
+- `type=2` (sent)
+- successful provider status/error values
+- `creator=com.ismartcoding.plain`
+- `restricted=1`
+
+Android 17's message-promotion implementation marks messages inserted for a non-default SMS package as read-restricted by default. A restricted row is filtered from provider queries unless the caller has the privileged `READ_RESTRICTED_MESSAGES` app-op. PlainApp does not have that app-op and should not attempt to bypass this platform boundary.
+
+The platform path is explicit in the Android 17 sources: the SMS provider applies `ReadRestriction.setReadRestrictionValueOnInsert()` during insertion, `Telephony.ReadRestriction` defaults the row to restricted when message promotion is enabled and the caller is not the default SMS package, and provider queries filter restricted rows unless the read-restricted-message app-op is allowed. See [GrapheneOS `SmsProvider`](https://github.com/GrapheneOS/platform_packages_providers_TelephonyProvider/blob/17/src/com/android/providers/telephony/SmsProvider.java), [`Telephony.ReadRestriction`](https://github.com/GrapheneOS/platform_frameworks_base/blob/17/core/java/android/provider/Telephony.java), and [`ProviderUtil.canReadRestrictedMessages`](https://github.com/GrapheneOS/platform_packages_providers_TelephonyProvider/blob/17/src/com/android/providers/telephony/ProviderUtil.java).
+
+The access-control diagnosis was verified reversibly: the same exact-ID GraphQL query returned no row with PlainApp's normal app-op state, returned the sent row while `READ_RESTRICTED_MESSAGES` was temporarily allowed through ADB, and returned no row again after the original ignored state was restored.
+
+### Provider reconciliation would otherwise match
+
+The original optimistic item and Android provider row were compared without exposing message content or destination data. Their thread, body, normalized destination, direction, and timestamp window all match. The row is absent only because the Android provider filters it before PlainApp's query receives results.
+
+### A successful terminal result is still rendered as pending
+
+`useMessageThread.handleSmsSendResult()` settles the failure deadline and starts three forced provider retries when a successful result arrives. If no readable provider row appears, the optimistic item remains in `pendingSmsItems`.
+
+`MessageChatBubble.vue` determines the visible state entirely from the `pending_sms` ID prefix. There is no successful-but-awaiting-reconciliation state, so an item whose send is conclusively successful is still rendered as “Sending…”. The successful result also cancels the only deadline that could remove or fail it, making the label permanent for the lifetime of that page state.
+
+## Root cause
+
+The bug is the interaction of two valid behaviors and one invalid frontend assumption:
+
+1. Android 17 read-restricts SMS rows created for a non-default messaging app while the platform's message-promotion flow is unresolved.
+2. PlainApp correctly lacks privileged access to read those restricted rows.
+3. The frontend assumes every successful sent callback will soon be followed by a queryable provider row and has no terminal “Sent, awaiting provider reconciliation” state.
+
+When assumption 3 is false, a successful send remains visually in progress forever.
+
+## Implemented correction
+
+The correction is confined to `plain-desktop`, which is the shared browser/Tauri frontend:
+
+1. Pending SMS operations now carry an explicit client-only `sending` or `sent` state.
+2. A correlated successful `SMS_SEND_RESULT` transitions only its matching operation to `sent` while retaining the optimistic item for provider reconciliation.
+3. Duplicate successful terminal results are ignored after the first state transition.
+4. Deadline startup reads the same pending-operation state, replacing the separate success set and preserving the result-before-mutation-response race protection.
+5. `MessageChatBubble` renders “Sent” for a successful optimistic SMS instead of deriving “Sending…” solely from its temporary ID.
+6. Existing provider matching remains unchanged: if Android later exposes the authoritative sent row, reconciliation removes the optimistic copy normally.
+
+## Regression coverage
+
+- `tests/lib/sms-state-sync.test.ts`
+  - proves a correlated success retains the optimistic item and marks it sent;
+  - proves a later matching provider row still reconciles it;
+  - proves a duplicate successful terminal result is idempotent.
+- `tests/hooks/message-thread.test.ts`
+  - proves a success that arrives before mutation acceptance prevents a false deadline;
+  - proves three unsuccessful provider retries leave the successful operation present and marked sent, without draft restoration or failure notification.
+
+## Validation
+
+### Before-fix evidence completed
+
+- Reproduced on current upstream / official 3.3.16.
+- Confirmed successful GraphQL mutation and correlated WebSocket terminal result.
+- Confirmed successful sent row in the Android provider.
+- Confirmed the row is excluded from PlainApp GraphQL under the normal app-op state.
+- Confirmed that temporarily allowing restricted-message reads makes the same row queryable, then restored the original app-op state.
+- Confirmed the optimistic and provider records would reconcile if the row were visible.
+
+### Post-fix validation
+
+- `corepack yarn test tests/lib/sms-state-sync.test.ts tests/hooks/message-thread.test.ts`: 20/20 tests passed.
+- `corepack yarn typecheck`: passed.
+- ESLint over every changed TypeScript/Vue/test file: passed.
+- `corepack yarn build`: production Vite build passed.
+- `corepack yarn test`: 483 passed and 52 skipped. Four pre-existing environment/isolation tests failed in unchanged `cross-window-store`, `local-mode`, and `window-client` suites; these are the same unrelated baseline failures already recorded in the main issue #345 report.
+- Real browser/device proof used the built production assets in an isolated Chrome tab against the official 3.3.16 Android backend. One authorized carrier SMS was sent from the conversation composer. The browser displayed “Sent” on the correlated bubble and still displayed “Sent” after all provider retries. The recipient confirmed receipt, while safe Android metadata confirmed that the persisted sent row was again `restricted=1` with successful provider status/error values.
+- PlainApp's `READ_RESTRICTED_MESSAGES` app-op was restored to its original ignored state after diagnosis and again verified after the test.
+
+## Remaining limitations
+
+Android controls whether and when a restricted provider row becomes readable to PlainApp. The frontend can truthfully display the successful terminal result and retain it for later reconciliation, but it must not grant itself privileged provider access. A full page reload cannot reconstruct a provider-filtered message unless the platform/default messaging app has promoted the row or PlainApp introduces a separate durable message store; that broader storage and privacy decision is outside this focused status fix.

--- a/docs/issues/345/android-17-restricted-sms-report.md
+++ b/docs/issues/345/android-17-restricted-sms-report.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/plainhub/plain-app/issues/345
 - Repositories: https://github.com/plainhub/plain-app and https://github.com/plainhub/plain-desktop
 - Branch/commit tested: `plain-app` `4ae019ba` (`v3.3.16`, current upstream); `plain-desktop` `d3b1ff1e` (current upstream)
-- Pull request: to be added after creation
+- Pull request: https://github.com/plainhub/plain-desktop/pull/17
 
 ## Priority and scope
 

--- a/src/hooks/message-thread.ts
+++ b/src/hooks/message-thread.ts
@@ -14,6 +14,7 @@ import {
   addPendingMms,
   addPendingSms,
   failPendingSms,
+  isPendingSmsSent,
   reconcilePendingSms,
   settlePendingMms,
   settlePendingSmsResult,
@@ -45,7 +46,6 @@ export function useMessageThread(
   const pendingSmsItems = ref<IMessage[]>([])
   const retryTimers = new Map<string, Set<ReturnType<typeof setTimeout>>>()
   const pendingMmsTimers = new Map<string, ReturnType<typeof setTimeout>>()
-  const successfulSmsResults = new Set<string>()
   let onTerminalSmsFailure: ((failed: IMessage) => void) | undefined
   let onTerminalMmsResult: ((pendingId: string, success: boolean) => void) | undefined
 
@@ -105,7 +105,6 @@ export function useMessageThread(
           if (!remainingPendingIds.has(pendingId)) {
             smsDeadlines.settle(pendingId)
             cancelRetry(pendingId)
-            successfulSmsResults.delete(pendingId)
           }
         }
         scrollToBottom()
@@ -173,7 +172,6 @@ export function useMessageThread(
   }
 
   function setPendingSms(body: string, address: string, requestId = `pending_sms_${shortUUID()}`) {
-    successfulSmsResults.delete(requestId)
     pendingSmsItems.value = addPendingSms(
       pendingSmsItems.value,
       requestId,
@@ -188,7 +186,7 @@ export function useMessageThread(
   }
 
   function startPendingSmsDeadline(requestId: string) {
-    if (!successfulSmsResults.has(requestId) && pendingSmsItems.value.some((item) => item.id === requestId)) {
+    if (pendingSmsItems.value.some((item) => item.id === requestId && !isPendingSmsSent(item))) {
       smsDeadlines.start(requestId)
     }
   }
@@ -196,14 +194,14 @@ export function useMessageThread(
   function handleSmsSendResult(result: ISmsSendResultEvent): { handled: boolean; failed?: IMessage } {
     const outcome = settlePendingSmsResult(pendingSmsItems.value, result)
     if (!outcome.handled || !result.requestId) return { handled: false }
+    if (!outcome.transitioned) return { handled: true }
+    pendingSmsItems.value = outcome.pending
     smsDeadlines.settle(result.requestId)
     if (result.success) {
-      successfulSmsResults.add(result.requestId)
       refetchWithRetry(result.requestId)
       return { handled: true }
     }
     cancelRetry(result.requestId)
-    pendingSmsItems.value = outcome.pending
     toast(t('send_failed'), 'error')
     return { handled: true, failed: outcome.failed }
   }
@@ -211,7 +209,6 @@ export function useMessageThread(
   function failPending(requestId: string): IMessage | undefined {
     const failed = failPendingSms(pendingSmsItems.value, requestId)
     pendingSmsItems.value = failed.pending
-    successfulSmsResults.delete(requestId)
     smsDeadlines.settle(requestId)
     cancelRetry(requestId)
     return failed.failed

--- a/src/lib/sms-state-sync.ts
+++ b/src/lib/sms-state-sync.ts
@@ -5,6 +5,11 @@ const MATCH_WINDOW_MS = 5 * 60 * 1000
 
 interface PendingSms extends IMessage {
   baselineIds?: string[]
+  sendState?: 'sending' | 'sent'
+}
+
+export function isPendingSmsSent(item: IMessage | undefined): boolean {
+  return Boolean(item && (item as PendingSms).sendState === 'sent')
 }
 
 export function addressesMatch(first: string, second: string): boolean {
@@ -45,6 +50,7 @@ export function addPendingSms(
       id: requestId,
       date: createdAt.toISOString(),
       baselineIds: [...baselineIds],
+      sendState: 'sending',
     } as PendingSms,
   ]
 }
@@ -87,12 +93,24 @@ export function failPendingSms(pending: IMessage[], requestId: string): { pendin
 export function settlePendingSmsResult(
   pending: IMessage[],
   result: ISmsSendResultEvent,
-): { pending: IMessage[]; handled: boolean; failed?: IMessage } {
-  if (!result.requestId || !pending.some((item) => item.id === result.requestId)) {
+): { pending: IMessage[]; handled: boolean; transitioned?: true; failed?: IMessage } {
+  const operation = result.requestId
+    ? pending.find((item) => item.id === result.requestId)
+    : undefined
+  if (!result.requestId || !operation) {
     return { pending, handled: false }
   }
-  if (result.success) return { pending, handled: true }
-  return { ...failPendingSms(pending, result.requestId), handled: true }
+  if (isPendingSmsSent(operation)) return { pending, handled: true }
+  if (result.success) {
+    return {
+      pending: pending.map((item) => item.id === result.requestId
+        ? { ...item, sendState: 'sent' } as PendingSms
+        : item),
+      handled: true,
+      transitioned: true,
+    }
+  }
+  return { ...failPendingSms(pending, result.requestId), handled: true, transitioned: true }
 }
 
 export function addPendingMms(pending: IMessage[], item: IMessage): IMessage[] {

--- a/src/views/messages/MessageChatBubble.vue
+++ b/src/views/messages/MessageChatBubble.vue
@@ -32,7 +32,7 @@
     <span v-tooltip="formatDateTime(item.date)" class="chat-time">{{ formatTime(item.date) }}</span>
     <span v-if="isDraftOrPending" class="chat-pending-status" :class="{ failed: pendingFailed }">
       <i-material-symbols:error-outline-rounded v-if="pendingFailed" class="pending-error-icon" />
-      {{ pendingFailed ? $t('mms_cancelled') : isPending ? $t('sending') : $t('message_type.3') }}
+      {{ $t(pendingStatusKey) }}
     </span>
   </div>
 </template>
@@ -43,6 +43,7 @@ import type { IMessage, ITag } from '@/lib/interfaces'
 import { formatDateTime, formatTime } from '@/lib/format'
 import { addLinksToURLs } from '@/lib/strutil'
 import { getFileUrlByPath } from '@/lib/api/file'
+import { isPendingSmsSent } from '@/lib/sms-state-sync'
 
 const props = defineProps<{
   item: IMessage
@@ -53,10 +54,16 @@ const props = defineProps<{
 
 const isSent = computed(() => props.item.type === 2 || props.item.type === 4)
 const isPending = computed(() => props.item.id.startsWith('pending_sms') || props.item.id.startsWith('pending_mms'))
+const pendingSmsSent = computed(() => isPendingSmsSent(props.item))
 const isDraftOrPending = computed(() => isPending.value || props.item.type === 3)
 const pendingFailed = computed(() => {
   if (!props.item.id.startsWith('pending_mms')) return false
   return Date.now() - new Date(props.item.date).getTime() > 5 * 60 * 1000
+})
+const pendingStatusKey = computed(() => {
+  if (pendingFailed.value) return 'mms_cancelled'
+  if (pendingSmsSent.value) return 'sent'
+  return isPending.value ? 'sending' : 'message_type.3'
 })
 
 function resolveUrl(path: string): string {

--- a/tests/hooks/message-thread.test.ts
+++ b/tests/hooks/message-thread.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { SMS_SEND_RESULT_TIMEOUT_MS } from '@/lib/sms-send-deadline'
+import { isPendingSmsSent } from '@/lib/sms-state-sync'
 
 const harness = vi.hoisted(() => ({ toast: vi.fn(), fetch: vi.fn() }))
 
@@ -75,6 +76,26 @@ describe('message thread pending operations', () => {
     await vi.advanceTimersByTimeAsync(SMS_SEND_RESULT_TIMEOUT_MS)
 
     expect(thread.pendingSmsItems.value.map((item) => item.id)).toEqual([requestId])
+    expect(isPendingSmsSent(thread.pendingSmsItems.value[0])).toBe(true)
+    expect(restore).not.toHaveBeenCalled()
+    expect(harness.toast).not.toHaveBeenCalled()
+  })
+
+  it('keeps a successful send marked sent when provider retries cannot see a restricted row', async () => {
+    vi.useFakeTimers()
+    harness.fetch.mockResolvedValue(undefined)
+    const thread = useMessageThread(ref('thread-a'), ref())
+    const restore = vi.fn()
+    thread.setTerminalHandlers({ onSmsFailure: restore, onMmsResult: vi.fn() })
+    const requestId = thread.setPendingSms('hello', '+15551234567', 'request-a')
+    thread.startPendingSmsDeadline(requestId)
+
+    expect(thread.handleSmsSendResult({ requestId, success: true }).handled).toBe(true)
+    await vi.advanceTimersByTimeAsync(7000)
+
+    expect(harness.fetch).toHaveBeenCalledTimes(3)
+    expect(thread.pendingSmsItems.value.map((item) => item.id)).toEqual([requestId])
+    expect(isPendingSmsSent(thread.pendingSmsItems.value[0])).toBe(true)
     expect(restore).not.toHaveBeenCalled()
     expect(harness.toast).not.toHaveBeenCalled()
   })

--- a/tests/lib/sms-state-sync.test.ts
+++ b/tests/lib/sms-state-sync.test.ts
@@ -4,6 +4,7 @@ import {
   addPendingMms,
   addPendingSms,
   failPendingSms,
+  isPendingSmsSent,
   reconcilePendingSms,
   settlePendingMms,
   settlePendingSmsResult,
@@ -92,6 +93,33 @@ describe('pending SMS state', () => {
 
     expect(first).toMatchObject({ handled: true, failed: { body: 'first' } })
     expect(duplicate).toEqual({ pending: [], handled: false })
+  })
+
+  it('marks a correlated successful send as sent while retaining it for provider reconciliation', () => {
+    const pending = addPendingSms(
+      [], 'pending-a', 'first', '+15551234567', 'thread-a', new Date('2026-08-28T10:00:00Z'),
+    )
+
+    const success = settlePendingSmsResult(pending, { requestId: 'pending-a', success: true })
+
+    expect(success.handled).toBe(true)
+    expect(success.pending.map((item) => item.id)).toEqual(['pending-a'])
+    expect(isPendingSmsSent(success.pending[0])).toBe(true)
+    expect(reconcilePendingSms(
+      success.pending,
+      [message({ body: 'first', date: '2026-08-28T10:00:01.000Z' })],
+      'thread-a',
+    )).toEqual([])
+  })
+
+  it('ignores a duplicate successful terminal result', () => {
+    const pending = addPendingSms([], 'pending-a', 'first', '+15551234567', 'thread-a')
+    const first = settlePendingSmsResult(pending, { requestId: 'pending-a', success: true })
+
+    expect(settlePendingSmsResult(
+      first.pending,
+      { requestId: 'pending-a', success: true },
+    )).toEqual({ pending: first.pending, handled: true })
   })
 })
 


### PR DESCRIPTION
## Summary

- mark a correlated optimistic SMS as sent when Android reports terminal success
- retain the optimistic item for later authoritative provider reconciliation
- render `Sent` instead of an indefinite `Sending...` status
- consume duplicate success results without restarting reconciliation retries
- add the Android 17 investigation report and focused regression coverage

Android 17 can mark SMS rows created for a non-default messaging app as read-restricted. PlainApp correctly cannot query those rows without a privileged app-op, so provider reconciliation may not complete even though the carrier send succeeded. This change trusts the already-correlated Android sent callback for the client-visible terminal status without bypassing the provider restriction.

Related to plainhub/plain-app#345.

## Validation

- `corepack yarn test tests/lib/sms-state-sync.test.ts tests/hooks/message-thread.test.ts` — 20 passed
- `corepack yarn typecheck` — passed
- ESLint over all changed TypeScript, Vue, and test files — passed
- `corepack yarn build --logLevel error` — passed
- production-build browser/device test — successful carrier SMS, `Sent` displayed before and after all provider retries; recipient confirmed receipt
- full repository suite — 483 passed, 52 skipped, with four unchanged environment/isolation failures in `cross-window-store`, `local-mode`, and `window-client` already documented on issue #345

## Report

See `docs/issues/345/android-17-restricted-sms-report.md` for the reproduction evidence, platform diagnosis, regression mapping, and remaining platform limitation.
