### PR TITLE
feat: add emoji shortcode autocomplete

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -93,6 +93,7 @@ declare module 'vue' {
     EditContactModal: typeof import('./src/components/EditContactModal.vue')['default']
     EditToolbar: typeof import('./src/components/EditToolbar.vue')['default']
     EditValueModal: typeof import('./src/components/EditValueModal.vue')['default']
+    EmojiTextField: typeof import('./src/components/EmojiTextField.vue')['default']
     ExcludedDirsModal: typeof import('./src/views/app-rail/ExcludedDirsModal.vue')['default']
     ExportSmsModal: typeof import('./src/views/messages/ExportSmsModal.vue')['default']
     ExtFilter: typeof import('./src/components/ExtFilter.vue')['default']

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-store": "^2.4.3",
+    "emojibase": "^17.0.0",
+    "emojibase-data": "^17.0.0",
     "htmlparser2": "^8.0.1",
     "jszip": "^3.10.1",
     "katex": "^0.16.45",

--- a/src/components/EmojiTextField.vue
+++ b/src/components/EmojiTextField.vue
@@ -1,0 +1,268 @@
+<template>
+  <div class="emoji-text-field">
+    <v-text-field
+      ref="fieldRef"
+      :model-value="modelValue"
+      v-bind="$attrs"
+      @input="onInput"
+      @click="onClick"
+      @focus="emit('focus', $event)"
+      @blur="onBlur"
+      @keyup.enter="emit('keyup.enter', $event)"
+      @paste="emit('paste', $event)"
+      @drop="emit('drop', $event)"
+      @dragenter="emit('dragenter', $event)"
+      @dragleave="emit('dragleave', $event)"
+      @keydown="onKeyDown"
+      @compositionstart="emit('compositionstart', $event)"
+      @compositionend="emit('compositionend', $event)"
+    >
+      <template v-if="$slots['leading-icon']" #leading-icon>
+        <slot name="leading-icon" />
+      </template>
+      <template v-if="$slots['trailing-icon']" #trailing-icon>
+        <slot name="trailing-icon" />
+      </template>
+    </v-text-field>
+    <div
+      v-if="activeShortcode && suggestions.length"
+      ref="menuRef"
+      class="emoji-suggestions"
+      role="listbox"
+      :aria-label="$t('emoji_suggestions')"
+    >
+      <button
+        v-for="(suggestion, index) in suggestions"
+        :key="suggestion.shortcode"
+        type="button"
+        class="emoji-suggestion"
+        :class="{ active: index === activeIndex }"
+        role="option"
+        :aria-selected="index === activeIndex"
+        @mouseenter="activeIndex = index"
+        @mousedown.prevent
+        @click="selectSuggestion(suggestion)"
+      >
+        <span class="emoji-suggestion-character">{{ suggestion.emoji }}</span>
+        <span class="emoji-suggestion-shortcode">:{{ suggestion.shortcode }}:</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+import {
+  applyEmojiSuggestion,
+  findActiveEmojiShortcode,
+  getEmojiSuggestions,
+  replaceCompletedEmojiShortcode,
+  type ActiveEmojiShortcode,
+  type EmojiSuggestion,
+} from '@/lib/emoji-shortcodes'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<{
+  modelValue?: string
+}>(), {
+  modelValue: '',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  input: [event: Event]
+  click: [event: MouseEvent]
+  focus: [event: FocusEvent]
+  blur: [event: FocusEvent]
+  'keyup.enter': [event: KeyboardEvent]
+  paste: [event: ClipboardEvent]
+  drop: [event: DragEvent]
+  dragenter: [event: DragEvent]
+  dragleave: [event: DragEvent]
+  keydown: [event: KeyboardEvent]
+  compositionstart: [event: CompositionEvent]
+  compositionend: [event: CompositionEvent]
+}>()
+
+interface TextFieldHandle {
+  focus: () => void
+  blur: () => void
+  getInputElement: () => HTMLInputElement | HTMLTextAreaElement | undefined
+}
+
+const fieldRef = ref<TextFieldHandle>()
+const menuRef = ref<HTMLElement>()
+const activeShortcode = ref<ActiveEmojiShortcode | null>(null)
+const suggestions = ref<EmojiSuggestion[]>([])
+const activeIndex = ref(0)
+const currentValue = ref(props.modelValue)
+
+watch(() => props.modelValue, (value) => {
+  currentValue.value = value
+})
+
+function updateSuggestions(value: string, caret: number) {
+  activeShortcode.value = findActiveEmojiShortcode(value, caret)
+  suggestions.value = activeShortcode.value ? getEmojiSuggestions(activeShortcode.value.query) : []
+  activeIndex.value = 0
+}
+
+function restoreCaret(caret: number) {
+  nextTick(() => {
+    const element = fieldRef.value?.getInputElement()
+    element?.focus()
+    element?.setSelectionRange(caret, caret)
+  })
+}
+
+function onInput(event: Event) {
+  const element = event.target as HTMLInputElement | HTMLTextAreaElement
+  const caret = element.selectionStart ?? element.value.length
+  if ((event as InputEvent).isComposing) {
+    currentValue.value = element.value
+    emit('update:modelValue', element.value)
+    emit('input', event)
+    return
+  }
+  const replacement = replaceCompletedEmojiShortcode(element.value, caret)
+
+  if (replacement) {
+    currentValue.value = replacement.value
+    element.value = replacement.value
+    emit('update:modelValue', replacement.value)
+    updateSuggestions(replacement.value, replacement.caret)
+    restoreCaret(replacement.caret)
+  } else {
+    currentValue.value = element.value
+    emit('update:modelValue', element.value)
+    updateSuggestions(element.value, caret)
+  }
+
+  emit('input', event)
+}
+
+function onKeyDown(event: KeyboardEvent) {
+  if (event.isComposing || !activeShortcode.value || !suggestions.value.length) {
+    emit('keydown', event)
+    return
+  }
+
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault()
+    const direction = event.key === 'ArrowDown' ? 1 : -1
+    activeIndex.value = (activeIndex.value + direction + suggestions.value.length) % suggestions.value.length
+    nextTick(() => menuRef.value?.children[activeIndex.value]?.scrollIntoView({ block: 'nearest' }))
+    return
+  }
+
+  const hasModifier = event.shiftKey || event.ctrlKey || event.altKey || event.metaKey
+  if (!hasModifier && (event.key === 'Enter' || event.key === 'Tab')) {
+    event.preventDefault()
+    selectSuggestion(suggestions.value[activeIndex.value])
+    return
+  }
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    activeShortcode.value = null
+    suggestions.value = []
+    return
+  }
+
+  if (event.key === 'ArrowLeft' || event.key === 'ArrowRight' || event.key === 'Home' || event.key === 'End') {
+    activeShortcode.value = null
+    suggestions.value = []
+  }
+
+  emit('keydown', event)
+}
+
+function onClick(event: MouseEvent) {
+  const element = event.target as HTMLInputElement | HTMLTextAreaElement
+  updateSuggestions(currentValue.value, element.selectionStart ?? currentValue.value.length)
+  emit('click', event)
+}
+
+function selectSuggestion(suggestion: EmojiSuggestion) {
+  if (!activeShortcode.value) return
+
+  const replacement = applyEmojiSuggestion(currentValue.value, activeShortcode.value, suggestion)
+  currentValue.value = replacement.value
+  emit('update:modelValue', replacement.value)
+  activeShortcode.value = null
+  suggestions.value = []
+  restoreCaret(replacement.caret)
+}
+
+function onBlur(event: FocusEvent) {
+  emit('blur', event)
+  window.setTimeout(() => {
+    activeShortcode.value = null
+    suggestions.value = []
+  })
+}
+
+defineExpose({
+  focus: () => fieldRef.value?.focus(),
+  blur: () => fieldRef.value?.blur(),
+  getInputElement: () => fieldRef.value?.getInputElement(),
+})
+</script>
+
+<style scoped lang="scss">
+.emoji-text-field {
+  position: relative;
+  width: 100%;
+}
+
+.emoji-suggestions {
+  position: absolute;
+  z-index: 30;
+  left: 0;
+  bottom: calc(100% + 6px);
+  width: min(320px, 100%);
+  max-height: 264px;
+  overflow-y: auto;
+  padding: 6px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 10px;
+  background: var(--md-sys-color-surface-container-high);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.emoji-suggestion {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 10px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
+  color: var(--md-sys-color-on-surface);
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover,
+  &.active {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+}
+
+.emoji-suggestion-character {
+  width: 26px;
+  font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+  font-size: 20px;
+  line-height: 1;
+  text-align: center;
+}
+
+.emoji-suggestion-shortcode {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/base/VTextField.vue
+++ b/src/components/base/VTextField.vue
@@ -11,6 +11,7 @@
           :placeholder="placeholder"
           :autocomplete="autocomplete"
           @input="handleInput"
+          @click="$emit('click', $event)"
           @focus="handleFocus"
           @blur="handleBlur"
           @keyup.enter="$emit('keyup.enter', $event)"
@@ -34,6 +35,7 @@
           :autocorrect="autocorrect"
           :spellcheck="spellcheck"
           @input="handleInput"
+          @click="$emit('click', $event)"
           @focus="handleFocus"
           @blur="handleBlur"
           @keyup.enter="$emit('keyup.enter', $event)"
@@ -87,6 +89,10 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   'update:modelValue': [value: string]
+  input: [event: Event]
+  click: [event: MouseEvent]
+  focus: [event: FocusEvent]
+  blur: [event: FocusEvent]
   'keyup.enter': [event: KeyboardEvent]
   paste: [event: ClipboardEvent]
   drop: [event: DragEvent]
@@ -112,14 +118,17 @@ const inputClass = computed(() => {
 const handleInput = (event: Event) => {
   const target = event.target as HTMLInputElement
   emit('update:modelValue', target.value)
+  emit('input', event)
 }
 
-const handleFocus = () => {
+const handleFocus = (event: FocusEvent) => {
   isFocused.value = true
+  emit('focus', event)
 }
 
-const handleBlur = () => {
+const handleBlur = (event: FocusEvent) => {
   isFocused.value = false
+  emit('blur', event)
 }
 
 defineExpose({
@@ -136,7 +145,8 @@ defineExpose({
     } else {
       inputRef.value?.blur()
     }
-  }
+  },
+  getInputElement: () => props.type === 'textarea' ? textareaRef.value : inputRef.value,
 })
 </script>
 
@@ -352,4 +362,4 @@ defineExpose({
     height: 24px;
   }
 }
-</style> 
+</style>

--- a/src/lib/emoji-shortcodes.ts
+++ b/src/lib/emoji-shortcodes.ts
@@ -1,0 +1,118 @@
+import shortcodeData from 'emojibase-data/en/shortcodes/iamcal.json'
+
+export interface EmojiSuggestion {
+  emoji: string
+  shortcode: string
+}
+
+export interface ActiveEmojiShortcode {
+  start: number
+  end: number
+  query: string
+}
+
+export interface EmojiReplacement {
+  value: string
+  caret: number
+}
+
+const MAX_SHORTCODE_LENGTH = 64
+const DEFAULT_SUGGESTION_LIMIT = 8
+const POPULAR_SHORTCODES = ['thumbsup', 'heart', 'joy', 'smile', 'laughing', 'tada', 'fire', 'eyes']
+
+const emojiByShortcode = new Map<string, string>()
+const shortcodeEntries: EmojiSuggestion[] = []
+
+function hexcodeToEmoji(hexcode: string): string {
+  const codepoints = hexcode.split('-').map((value) => Number.parseInt(value, 16))
+  let emoji = String.fromCodePoint(...codepoints)
+  if (codepoints.length === 1 && /\p{Emoji}/u.test(emoji) && !/\p{Emoji_Presentation}/u.test(emoji)) {
+    emoji += '\uFE0F'
+  }
+  return emoji
+}
+
+for (const [hexcode, value] of Object.entries(shortcodeData)) {
+  const emoji = hexcodeToEmoji(hexcode)
+
+  const shortcodes = Array.isArray(value) ? value : [value]
+  for (const shortcode of shortcodes) {
+    const normalized = shortcode.toLowerCase()
+    if (emojiByShortcode.has(normalized)) continue
+    emojiByShortcode.set(normalized, emoji)
+    shortcodeEntries.push({ emoji, shortcode })
+  }
+}
+
+const popularSuggestions = POPULAR_SHORTCODES.flatMap((shortcode) => {
+  const emoji = emojiByShortcode.get(shortcode)
+  return emoji ? [{ emoji, shortcode }] : []
+})
+
+function shortcodePattern(closingColon: boolean): RegExp {
+  const suffix = closingColon ? ':$' : '$'
+  return new RegExp(`(?:^|\\s):([a-z0-9_+\\-]{${closingColon ? 1 : 0},${MAX_SHORTCODE_LENGTH}})${suffix}`, 'i')
+}
+
+function shortcodeStart(match: RegExpExecArray): number {
+  return match.index + match[0].indexOf(':')
+}
+
+export function findActiveEmojiShortcode(value: string, caret: number): ActiveEmojiShortcode | null {
+  if (caret < 0 || caret > value.length) return null
+
+  const match = shortcodePattern(false).exec(value.slice(0, caret))
+  if (!match) return null
+
+  return {
+    start: shortcodeStart(match),
+    end: caret,
+    query: match[1].toLowerCase(),
+  }
+}
+
+export function getEmojiSuggestions(query: string, limit = DEFAULT_SUGGESTION_LIMIT): EmojiSuggestion[] {
+  if (limit <= 0) return []
+
+  const normalized = query.toLowerCase()
+  if (!normalized) return popularSuggestions.slice(0, limit)
+
+  return shortcodeEntries
+    .filter((item) => item.shortcode.toLowerCase().includes(normalized))
+    .sort((a, b) => {
+      const aName = a.shortcode.toLowerCase()
+      const bName = b.shortcode.toLowerCase()
+      const aScore = aName === normalized ? 0 : aName.startsWith(normalized) ? 1 : 2
+      const bScore = bName === normalized ? 0 : bName.startsWith(normalized) ? 1 : 2
+      return aScore - bScore || aName.length - bName.length || aName.localeCompare(bName)
+    })
+    .slice(0, limit)
+}
+
+export function applyEmojiSuggestion(
+  value: string,
+  active: ActiveEmojiShortcode,
+  suggestion: EmojiSuggestion,
+): EmojiReplacement {
+  const nextValue = value.slice(0, active.start) + suggestion.emoji + value.slice(active.end)
+  return {
+    value: nextValue,
+    caret: active.start + suggestion.emoji.length,
+  }
+}
+
+export function replaceCompletedEmojiShortcode(value: string, caret: number): EmojiReplacement | null {
+  if (caret < 0 || caret > value.length) return null
+
+  const match = shortcodePattern(true).exec(value.slice(0, caret))
+  if (!match) return null
+
+  const emoji = emojiByShortcode.get(match[1].toLowerCase())
+  if (!emoji) return null
+
+  const start = shortcodeStart(match)
+  return {
+    value: value.slice(0, start) + emoji + value.slice(caret),
+    caret: start + emoji.length,
+  }
+}

--- a/src/locales/bn/messages.ts
+++ b/src/locales/bn/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'একটি বার্তা লিখুন',
+  emoji_suggestions: 'ইমোজি পরামর্শ',
   send_sms: 'এসএমএস পাঠান',
   send_mms: 'এমএমএস পাঠান',
   confirm_mms_on_phone: 'অনুগ্রহ করে আপনার ফোনে এমএমএস নিশ্চিত করে পাঠান।',

--- a/src/locales/de/messages.ts
+++ b/src/locales/de/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Nachricht schreiben',
+  emoji_suggestions: 'Emoji-Vorschläge',
   confirm_mms_on_phone: 'Bitte bestätigen und senden Sie die MMS auf Ihrem Telefon.',
   send_sms: 'SMS senden',
   send_mms: 'MMS senden',

--- a/src/locales/en-US/messages.ts
+++ b/src/locales/en-US/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Write a message',
+  emoji_suggestions: 'Emoji suggestions',
   confirm_mms_on_phone: 'Please confirm and send the MMS on your phone.',
   send_sms: 'Send SMS',
   send_mms: 'Send MMS',

--- a/src/locales/es/messages.ts
+++ b/src/locales/es/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Escribir un mensaje',
+  emoji_suggestions: 'Sugerencias de emojis',
   confirm_mms_on_phone: 'Por favor, confirme y envíe el MMS en su teléfono.',
   send_sms: 'Enviar SMS',
   send_mms: 'Enviar MMS',

--- a/src/locales/fr/messages.ts
+++ b/src/locales/fr/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Écrire un message',
+  emoji_suggestions: 'Suggestions d’émojis',
   confirm_mms_on_phone: 'Veuillez confirmer et envoyer le MMS sur votre téléphone.',
   send_sms: 'Envoyer un SMS',
   send_mms: 'Envoyer MMS',

--- a/src/locales/hi/messages.ts
+++ b/src/locales/hi/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'संदेश लिखें',
+  emoji_suggestions: 'इमोजी सुझाव',
   send_sms: 'SMS भेजें',
   send_mms: 'MMS भेजें',
   confirm_mms_on_phone: 'कृपया अपने फ़ोन पर MMS की पुष्टि करें और भेजें।',

--- a/src/locales/it/messages.ts
+++ b/src/locales/it/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Scrivi un messaggio',
+  emoji_suggestions: 'Suggerimenti emoji',
   confirm_mms_on_phone: 'Per favore, conferma e invia l\'MMS sul tuo telefono.',
   send_sms: 'Invia SMS',
   send_mms: 'Invia MMS',

--- a/src/locales/ja/messages.ts
+++ b/src/locales/ja/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'メッセージを入力',
+  emoji_suggestions: '絵文字の候補',
   confirm_mms_on_phone: '電話でMMSを確認して送信してください。',
   send_sms: 'SMSを送信',
   send_mms: 'MMS送信',

--- a/src/locales/ko/messages.ts
+++ b/src/locales/ko/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: '메시지 입력',
+  emoji_suggestions: '이모지 추천',
   confirm_mms_on_phone: '휴대폰에서 MMS를 확인하고 전송해 주세요.',
   send_sms: '문자 보내기',
   send_mms: 'MMS 보내기',

--- a/src/locales/nl/messages.ts
+++ b/src/locales/nl/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Schrijf een bericht',
+  emoji_suggestions: 'Emoji-suggesties',
   confirm_mms_on_phone: 'Bevestig en verzend de MMS op uw telefoon.',
   mms_cancelled: 'Geannuleerd (niet verzonden)',
   send_sms: 'SMS verzenden',

--- a/src/locales/pt/messages.ts
+++ b/src/locales/pt/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Escreva uma mensagem',
+  emoji_suggestions: 'Sugestões de emojis',
   send_sms: 'Enviar SMS',
   send_mms: 'Enviar MMS',
   confirm_mms_on_phone: 'Por favor, confirme e envie a MMS no seu telefone.',

--- a/src/locales/ru/messages.ts
+++ b/src/locales/ru/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Написать сообщение',
+  emoji_suggestions: 'Предложения эмодзи',
   confirm_mms_on_phone: 'Пожалуйста, подтвердите и отправьте MMS на вашем телефоне.',
   send_sms: 'Отправить SMS',
   send_mms: 'Отправить MMS',

--- a/src/locales/ta/messages.ts
+++ b/src/locales/ta/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'ஒரு செய்தி எழுதுங்கள்',
+  emoji_suggestions: 'எமோஜி பரிந்துரைகள்',
   send_sms: 'SMS அனுப்பு',
   send_mms: 'MMS அனுப்பு',
   confirm_mms_on_phone: 'MMS ஐ உங்கள் கைபேசியில் உறுதிப்படுத்தி அனுப்பவும்.',

--- a/src/locales/tr/messages.ts
+++ b/src/locales/tr/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Bir mesaj yazın',
+  emoji_suggestions: 'Emoji önerileri',
   send_sms: 'SMS gönder',
   send_mms: 'MMS Gönder',
   confirm_mms_on_phone: 'Lütfen MMS\'i telefonunuzda onaylayın ve gönderin.',

--- a/src/locales/vi/messages.ts
+++ b/src/locales/vi/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: 'Viết tin nhắn',
+  emoji_suggestions: 'Gợi ý emoji',
   send_sms: 'Gửi SMS',
   send_mms: 'Gửi MMS',
   confirm_mms_on_phone: 'Vui lòng xác nhận và gửi MMS trên điện thoại của bạn.',

--- a/src/locales/zh-CN/messages.ts
+++ b/src/locales/zh-CN/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: '输入消息',
+  emoji_suggestions: '表情符号建议',
   confirm_mms_on_phone: '请在手机上确认并发送彩信。',
   send_sms: '发送短信',
   send_mms: '发送彩信',

--- a/src/locales/zh-TW/messages.ts
+++ b/src/locales/zh-TW/messages.ts
@@ -1,5 +1,6 @@
 export default {
   write_a_message: '輸入訊息',
+  emoji_suggestions: '表情符號建議',
   confirm_mms_on_phone: '請在手機上確認並傳送多媒體簡訊。',
   send_sms: '發送簡訊',
   send_mms: '傳送多媒體簡訊',

--- a/src/views/chat/ChatInput.vue
+++ b/src/views/chat/ChatInput.vue
@@ -3,7 +3,7 @@
   <div class="chat-input">
     <div class="textarea-wrapper">
       <div v-show="displayDragMask" class="drag-mask">{{ $t('release_to_send_files') }}</div>
-      <v-text-field
+      <EmojiTextField
         :model-value="modelValue"
         type="textarea"
         :rows="2"
@@ -34,7 +34,7 @@
             <i-material-symbols:send-outline-rounded />
           </v-icon-button>
         </template>
-      </v-text-field>
+      </EmojiTextField>
     </div>
     <input ref="fileInput" style="display: none" type="file" multiple @change="uploadFilesChanged" />
     <input ref="imageInput" style="display: none" type="file" accept="image/*, video/*" multiple @change="uploadImagesChanged" />

--- a/src/views/messages/MessageChatInput.vue
+++ b/src/views/messages/MessageChatInput.vue
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div class="textarea-wrapper">
-      <v-text-field
+      <EmojiTextField
         :model-value="modelValue"
         type="textarea"
         :rows="1"
@@ -48,7 +48,7 @@
             <i-material-symbols:send-outline-rounded />
           </v-icon-button>
         </template>
-      </v-text-field>
+      </EmojiTextField>
       <input ref="fileInputRef" type="file" multiple accept="image/*,video/*,audio/*" class="hidden-file-input" @change="$emit('fileSelected', $event)" />
     </div>
   </div>

--- a/src/views/messages/SendSmsModal.vue
+++ b/src/views/messages/SendSmsModal.vue
@@ -33,7 +33,7 @@
         </div>
       </div>
       <div class="form-row">
-        <v-text-field v-model="body" type="textarea" :rows="4" :label="$t('content')" :error="!!errors.body && pendingFiles.length === 0" :error-text="errors.body && pendingFiles.length === 0 ? $t(errors.body) : ''" />
+        <EmojiTextField v-model="body" type="textarea" :rows="4" :label="$t('content')" :error="!!errors.body && pendingFiles.length === 0" :error-text="errors.body && pendingFiles.length === 0 ? $t(errors.body) : ''" />
       </div>
       <div class="form-row">
         <input ref="fileInputRef" type="file" multiple accept="image/*,video/*,audio/*" class="hidden-file-input" @change="onFileSelected" />
@@ -192,4 +192,3 @@ const {
 }
 
 </style>
-

--- a/src/views/notifications/PNotifications.vue
+++ b/src/views/notifications/PNotifications.vue
@@ -63,7 +63,7 @@
             </v-outlined-button>
           </div>
           <div v-if="replyingId === item.id" class="reply-box">
-            <v-text-field v-model="replyText" type="textarea" :rows="2" :placeholder="$t('type_a_reply')" />
+            <EmojiTextField v-model="replyText" type="textarea" :rows="2" :placeholder="$t('type_a_reply')" />
             <div class="reply-box-actions">
               <v-outlined-button class="btn-sm" @click.stop="cancelReply">Cancel</v-outlined-button>
               <v-filled-button class="btn-sm" :loading="replySending" :disabled="!replyText.trim()" @click.stop="sendReply(item.id)">Send</v-filled-button>

--- a/tests/components/emoji-text-field.test.ts
+++ b/tests/components/emoji-text-field.test.ts
@@ -1,0 +1,100 @@
+import { createApp, h, nextTick, ref } from 'vue'
+import { afterEach, describe, expect, it } from 'vitest'
+import EmojiTextField from '@/components/EmojiTextField.vue'
+import VTextField from '@/components/base/VTextField.vue'
+
+function mountField() {
+  const modelValue = ref('')
+  const keydowns = ref(0)
+  const root = document.createElement('div')
+  document.body.append(root)
+
+  const app = createApp({
+    setup() {
+      return () => h(EmojiTextField, {
+        modelValue: modelValue.value,
+        type: 'textarea',
+        'onUpdate:modelValue': (value: string) => { modelValue.value = value },
+        onKeydown: () => { keydowns.value += 1 },
+      })
+    },
+  })
+  app.component('VTextField', VTextField)
+  app.config.globalProperties.$t = (key: string) => key
+  app.mount(root)
+
+  return { app, root, modelValue, keydowns }
+}
+
+const mountedApps: ReturnType<typeof mountField>[] = []
+
+afterEach(() => {
+  for (const mounted of mountedApps.splice(0)) {
+    mounted.app.unmount()
+    mounted.root.remove()
+  }
+})
+
+async function setValue(textarea: HTMLTextAreaElement, value: string) {
+  textarea.value = value
+  textarea.setSelectionRange(value.length, value.length)
+  textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  await nextTick()
+}
+
+describe('EmojiTextField', () => {
+  it('opens suggestions and inserts the active emoji with Enter', async () => {
+    const mounted = mountField()
+    mountedApps.push(mounted)
+    const textarea = mounted.root.querySelector('textarea')!
+
+    await setValue(textarea, ':smi')
+
+    expect(mounted.root.querySelector('[role="listbox"]')).not.toBeNull()
+    expect(mounted.root.querySelector('.emoji-suggestion-shortcode')?.textContent).toBe(':smile:')
+
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+    await nextTick()
+
+    expect(mounted.modelValue.value).toBe('😄')
+    expect(mounted.root.querySelector('[role="listbox"]')).toBeNull()
+    expect(mounted.keydowns.value).toBe(0)
+  })
+
+  it('converts a completed shortcode as it is typed', async () => {
+    const mounted = mountField()
+    mountedApps.push(mounted)
+    const textarea = mounted.root.querySelector('textarea')!
+    await setValue(textarea, 'Celebrate :tada:')
+
+    expect(mounted.modelValue.value).toBe('Celebrate 🎉')
+  })
+
+  it('passes Enter through when no emoji menu is open', async () => {
+    const mounted = mountField()
+    mountedApps.push(mounted)
+    const textarea = mounted.root.querySelector('textarea')!
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+    await nextTick()
+
+    expect(mounted.keydowns.value).toBe(1)
+  })
+
+  it('passes modified Enter through instead of selecting an emoji', async () => {
+    const mounted = mountField()
+    mountedApps.push(mounted)
+    const textarea = mounted.root.querySelector('textarea')!
+    await setValue(textarea, ':smi')
+
+    textarea.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    }))
+    await nextTick()
+
+    expect(mounted.modelValue.value).toBe(':smi')
+    expect(mounted.keydowns.value).toBe(1)
+  })
+})

--- a/tests/lib/emoji-shortcodes.test.ts
+++ b/tests/lib/emoji-shortcodes.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyEmojiSuggestion,
+  findActiveEmojiShortcode,
+  getEmojiSuggestions,
+  replaceCompletedEmojiShortcode,
+} from '@/lib/emoji-shortcodes'
+
+describe('emoji shortcodes', () => {
+  it('finds a shortcode at the caret after whitespace', () => {
+    expect(findActiveEmojiShortcode('hello :smi', 10)).toEqual({
+      start: 6,
+      end: 10,
+      query: 'smi',
+    })
+  })
+
+  it('does not treat URL schemes or times as emoji shortcodes', () => {
+    expect(findActiveEmojiShortcode('https://example.com', 6)).toBeNull()
+    expect(findActiveEmojiShortcode('Meet at 10:', 11)).toBeNull()
+  })
+
+  it('ranks exact and prefix matches before substring matches', () => {
+    const suggestions = getEmojiSuggestions('smile')
+    expect(suggestions[0]).toMatchObject({ emoji: '😄', shortcode: 'smile' })
+    expect(suggestions.some((item) => item.shortcode.includes('smile'))).toBe(true)
+  })
+
+  it('offers popular emoji after a bare colon', () => {
+    const suggestions = getEmojiSuggestions('')
+    expect(suggestions).toHaveLength(8)
+    expect(suggestions[0]).toMatchObject({ emoji: '👍', shortcode: 'thumbsup' })
+  })
+
+  it('applies a selected suggestion without disturbing surrounding text', () => {
+    const active = findActiveEmojiShortcode('before :hea after', 11)
+    expect(active).not.toBeNull()
+    expect(applyEmojiSuggestion('before :hea after', active!, { emoji: '❤️', shortcode: 'heart' })).toEqual({
+      value: 'before ❤️ after',
+      caret: 9,
+    })
+  })
+
+  it('converts a completed shortcode at the caret', () => {
+    expect(replaceCompletedEmojiShortcode('Hello :tada: world', 12)).toEqual({
+      value: 'Hello 🎉 world',
+      caret: 8,
+    })
+  })
+
+  it('leaves unknown completed shortcodes unchanged', () => {
+    expect(replaceCompletedEmojiShortcode(':plainapp:', 10)).toBeNull()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -172,6 +172,7 @@ export default defineConfig(({ mode }) => {
     },
     projects: [
       {
+        plugins: [vue()],
         resolve: {
           alias: {
             '@': path.resolve(__dirname, 'src'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,6 +3157,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emojibase-data@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "emojibase-data@npm:17.0.0"
+  peerDependencies:
+    emojibase: "*"
+  checksum: 10/124e24063c6123c29e9ccb716d88c376beba33c87f2bb6ec7d207d0a2ccf2831d83bf36c95363ff32b9e2c87d32d1b8ddf2e8d2776da804cabe5d0b7d47fde3f
+  languageName: node
+  linkType: hard
+
+"emojibase@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "emojibase@npm:17.0.0"
+  checksum: 10/8ee6b0cc6ca807e11a1ec72288cc83477f82eedd9f57a69ccbb7d120f811ff3b30d4ff42c100226dde7576f6b17a77f22d2aa103541f208b30dcde1da23dbe4e
+  languageName: node
+  linkType: hard
+
 "entities@npm:^4.2.0, entities@npm:^4.4.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
@@ -4718,6 +4734,8 @@ __metadata:
     "@vue/eslint-config-typescript": "npm:^14.5.0"
     "@vue/test-utils": "npm:^2.4.6"
     "@vue/tsconfig": "npm:^0.7.0"
+    emojibase: "npm:^17.0.0"
+    emojibase-data: "npm:^17.0.0"
     eslint: "npm:^9.28.0"
     eslint-plugin-vue: "npm:^10.1.0"
     htmlparser2: "npm:^8.0.1"


### PR DESCRIPTION
## Summary

- add Slack-style `:shortcode:` emoji autocomplete to SMS/MMS conversations, the new-message dialog, PlainApp peer chat, and notification replies
- support mouse selection plus `ArrowUp`/`ArrowDown`, `Enter`, `Tab`, and `Escape` keyboard controls without accidentally sending the message
- convert completed aliases such as `:tada:` directly while preserving the caret and leaving URLs, times, and unknown shortcodes untouched
- use the current Emojibase iamcal shortcode dataset and localize the suggestion list's accessibility label across all supported locales

## Tests

- `corepack yarn typecheck`
- `corepack yarn test --project=unit tests/lib/emoji-shortcodes.test.ts tests/components/emoji-text-field.test.ts` — 11 passed
- targeted ESLint over all changed source and test files
- `VITE_APP_API_HOST='' corepack yarn build`
- corresponding bundled assets built successfully in all three PlainApp debug APK flavors with `./gradlew :app:assembleDebug`

## Full-suite note

A full `corepack yarn test` run reached 490 passing and 52 skipped tests. Three existing local-mode assertions fail against current upstream because they expect `isLocalMode()` to be true in a web build while the current implementation explicitly gates it on `__IS_TAURI__`. The cross-window-store timing test also failed once in the combined run and passed immediately when rerun in isolation. None of those modules are changed here.
