### PR TITLE
feat: bulk-move selected images to a folder on the images page

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -242,6 +242,7 @@ declare module 'vue' {
     'IMaterialSymbols:downloadRounded': typeof import('~icons/material-symbols/download-rounded')['default']
     'IMaterialSymbols:draftOutlineRounded': typeof import('~icons/material-symbols/draft-outline-rounded')['default']
     'IMaterialSymbols:dragIndicator': typeof import('~icons/material-symbols/drag-indicator')['default']
+    'IMaterialSymbols:driveFileMoveOutlineRounded': typeof import('~icons/material-symbols/drive-file-move-outline-rounded')['default']
     'IMaterialSymbols:edit': typeof import('~icons/material-symbols/edit')['default']
     'IMaterialSymbols:editOutlineRounded': typeof import('~icons/material-symbols/edit-outline-rounded')['default']
     'IMaterialSymbols:editRounded': typeof import('~icons/material-symbols/edit-rounded')['default']

--- a/src/hooks/media.ts
+++ b/src/hooks/media.ts
@@ -1,6 +1,6 @@
 import { useI18n } from 'vue-i18n'
 import toast from '@/components/toaster'
-import { deleteMediaItemsGQL, initMutation } from '@/lib/api/mutation'
+import { deleteMediaItemsGQL, initMutation, moveMediaItemsGQL } from '@/lib/api/mutation'
 import emitter from '@/plugins/eventbus'
 import type { DataType } from '@/lib/data'
 import { encodeBase64 } from '@/lib/strutil'
@@ -60,6 +60,40 @@ export const useDeleteItems = () => {
         emitter.emit('media_items_actioned', { type, action: 'delete', id: item.id, query: `ids:${item.id}` })
       }
       doDeleteItem({ type, query: `ids:${item.id}` })
+    },
+  }
+}
+
+
+export const useMoveItems = () => {
+  const { t } = useI18n()
+  const moveType = ref('')
+  const moveQuery = ref('')
+
+  const { mutate: doMove, loading: moveLoading, onDone: onMoveDone } = initMutation({ document: moveMediaItemsGQL })
+  onMoveDone(() => {
+    const type = moveType.value
+    const q = moveQuery.value
+    emitter.emit('media_items_actioned', { type, action: 'move', query: q })
+  })
+
+  return {
+    moveLoading,
+    moveItems: (type: string, ids: string[], realAllChecked: boolean, query: string) => {
+      let q = query
+      if (!realAllChecked) {
+        if (ids.length === 0) {
+          toast(t('select_first'), 'error')
+          return
+        }
+        q = `ids:${ids.join(',')}`
+      }
+      moveType.value = type
+      moveQuery.value = q
+      return q
+    },
+    doMoveItems: (destDir: string) => {
+      doMove({ type: moveType.value, query: moveQuery.value, destDir })
     },
   }
 }

--- a/src/lib/api/mutation.ts
+++ b/src/lib/api/mutation.ts
@@ -297,6 +297,15 @@ export const restoreMediaItemsGQL = `
   }
 `
 
+export const moveMediaItemsGQL = `
+  mutation moveMediaItems($type: DataType!, $query: String!, $destDir: String!) {
+    moveMediaItems(type: $type, query: $query, destDir: $destDir) {
+      type
+      query
+    }
+  }
+`
+
 export const removeFromTagsGQL = `
   mutation removeFromTags($type: DataType!, $tagIds: [ID!]!, $query: String!) {
     removeFromTags(type: $type, tagIds: $tagIds, query: $query)

--- a/src/locales/bn/common.ts
+++ b/src/locales/bn/common.ts
@@ -191,6 +191,7 @@ export default {
   restore: 'পুনরুদ্ধার',
   trash: 'ট্র্যাশ',
   move_to_trash: 'ট্র্যাশে সরান',
+  move_to_folder: 'ফোল্ডারে সরান',
   work: 'কাজ',
   expand_all: 'সব বিস্তার করুন',
   collapse_all: 'সব সংকুচিত করুন',

--- a/src/locales/de/common.ts
+++ b/src/locales/de/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: 'Wiederherstellen',
   trash: 'Papierkorb',
   move_to_trash: 'In den Papierkorb verschieben',
+  move_to_folder: 'In Ordner verschieben',
   work: 'Arbeit',
   expand_all: 'Alle erweitern',
   collapse_all: 'Alle minimieren',

--- a/src/locales/en-US/common.ts
+++ b/src/locales/en-US/common.ts
@@ -229,6 +229,7 @@ export default {
   not_in_trash: 'Not in trash',
   trash: 'Trash',
   move_to_trash: 'Move to trash',
+  move_to_folder: 'Move to folder',
   work: 'Work',
   expand_all: 'Expand all',
   collapse_all: 'Collapse all',

--- a/src/locales/es/common.ts
+++ b/src/locales/es/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: 'Restaurar',
   trash: 'Papelera',
   move_to_trash: 'Mover a la papelera',
+  move_to_folder: 'Mover a la carpeta',
   work: 'Trabajo',
   expand_all: 'Expandir todo',
   collapse_all: 'Contraer todo',

--- a/src/locales/fr/common.ts
+++ b/src/locales/fr/common.ts
@@ -188,6 +188,7 @@ export default {
   restore: 'Restaurer',
   trash: 'Corbeille',
   move_to_trash: 'Déplacer vers la corbeille',
+  move_to_folder: 'Déplacer vers le dossier',
   work: 'Travail',
   expand_all: 'Tout développer',
   collapse_all: 'Tout réduire',

--- a/src/locales/hi/common.ts
+++ b/src/locales/hi/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: 'रिस्टोर',
   trash: 'ट्रैश',
   move_to_trash: 'मूव टू ट्रैश',
+  move_to_folder: 'फ़ोल्डर में ले जाएँ',
   work: 'वर्क',
   expand_all: 'एक्सपैंड ऑल',
   collapse_all: 'कोलॅप्स ऑल',

--- a/src/locales/it/common.ts
+++ b/src/locales/it/common.ts
@@ -188,6 +188,7 @@ export default {
   restore: 'Ripristina',
   trash: 'Cestino',
   move_to_trash: 'Sposta nel cestino',
+  move_to_folder: 'Sposta nella cartella',
   work: 'Lavoro',
   expand_all: 'Espandi tutto',
   collapse_all: 'Comprimi tutto',

--- a/src/locales/ja/common.ts
+++ b/src/locales/ja/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: '復元',
   trash: 'ゴミ箱',
   move_to_trash: 'ゴミ箱に移動',
+  move_to_folder: 'フォルダに移動',
   work: '作業',
   expand_all: 'すべて展開',
   collapse_all: 'すべて折りたたむ',

--- a/src/locales/ko/common.ts
+++ b/src/locales/ko/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: '복원',
   trash: '휴지통',
   move_to_trash: '휴지통으로 이동',
+  move_to_folder: '폴더로 이동',
   work: '작업',
   expand_all: '모두 펼치기',
   collapse_all: '모두 축소하기',

--- a/src/locales/nl/common.ts
+++ b/src/locales/nl/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: 'Herstellen',
   trash: 'Prullenbak',
   move_to_trash: 'Naar prullenbak verplaatsen',
+  move_to_folder: 'Naar map verplaatsen',
   work: 'Werk',
   expand_all: 'Alles uitvouwen',
   collapse_all: 'Alles samenvouwen',

--- a/src/locales/pt/common.ts
+++ b/src/locales/pt/common.ts
@@ -186,6 +186,7 @@ export default {
   restore: 'Restaurar',
   trash: 'Lixo',
   move_to_trash: 'Mover para o lixo',
+  move_to_folder: 'Mover para a pasta',
   work: 'Trabalho',
   expand_all: 'Expandir tudo',
   collapse_all: 'Recolher tudo',

--- a/src/locales/ru/common.ts
+++ b/src/locales/ru/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: 'Восстановить',
   trash: 'Корзина',
   move_to_trash: 'Переместить в корзину',
+  move_to_folder: 'Переместить в папку',
   work: 'Работа',
   expand_all: 'Развернуть все',
   collapse_all: 'Свернуть все',

--- a/src/locales/ta/common.ts
+++ b/src/locales/ta/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: 'மீட்டமை',
   trash: 'குப்பை',
   move_to_trash: 'குப்பைக்கு நகர்த்து',
+  move_to_folder: 'கோப்புறைக்கு நகர்த்து',
   work: 'வேலை',
   expand_all: 'அனைத்தையும் விரிக்க',
   collapse_all: 'அனைத்தையும் மூடு',

--- a/src/locales/tr/common.ts
+++ b/src/locales/tr/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: 'Geri yükle',
   trash: 'Çöp',
   move_to_trash: 'Çöpe taşı',
+  move_to_folder: 'Klasöre taşı',
   work: 'İş',
   expand_all: 'Hepsini genişlet',
   collapse_all: 'Hepsini daralt',

--- a/src/locales/vi/common.ts
+++ b/src/locales/vi/common.ts
@@ -187,6 +187,7 @@ export default {
   restore: 'Khôi phục',
   trash: 'Thùng rác',
   move_to_trash: 'Di chuyển vào thùng rác',
+  move_to_folder: 'Di chuyển vào thư mục',
   work: 'Công việc',
   expand_all: 'Mở rộng tất cả',
   collapse_all: 'Thu gọn tất cả',

--- a/src/locales/zh-CN/common.ts
+++ b/src/locales/zh-CN/common.ts
@@ -221,6 +221,7 @@ export default {
   not_in_trash: '不在回收站',
   trash: '回收站',
   move_to_trash: '移到回收站',
+  move_to_folder: '移动到文件夹',
   work: '工作',
   expand_all: '展开全部',
   collapse_all: '合并全部',

--- a/src/locales/zh-TW/common.ts
+++ b/src/locales/zh-TW/common.ts
@@ -188,6 +188,7 @@ export default {
   restore: '還原',
   trash: '資源回收筒',
   move_to_trash: '移至資源回收筒',
+  move_to_folder: '移動到資料夾',
   work: '工作',
   expand_all: '展開全部',
   collapse_all: '收合全部',

--- a/src/views/images/ImagesView.vue
+++ b/src/views/images/ImagesView.vue
@@ -18,6 +18,11 @@
     <template #tag-action>
       <BulkTagDropdown :type="dataType" :tags="tags" :items="items" :selected-ids="selectedIds" :real-all-checked="realAllChecked" :q="q" />
     </template>
+    <template #extra-actions>
+      <v-icon-button v-if="!filter.trash" v-tooltip="$t('move_to_folder')" :loading="moveLoading" @click.stop="onMoveClick">
+        <i-material-symbols:drive-file-move-outline-rounded />
+      </v-icon-button>
+    </template>
     <template #actions>
       <ImageSearchButton />
       <MediaPageActions v-bind="actionsProps" placement="top" />
@@ -113,6 +118,10 @@ import MediaToolbar from '@/components/media/MediaToolbar.vue'
 import ImageSearchButton from '@/components/ai/ImageSearchButton.vue'
 import NoDataPlaceholder from '@/components/NoDataPlaceholder.vue'
 import { useOpenMedia } from '@/hooks/open-media'
+import { useMoveItems } from '@/hooks/media'
+import { promptModal } from '@/components/modal'
+import DirectoryPickerModal from '@/components/DirectoryPickerModal.vue'
+import { useI18n } from 'vue-i18n'
 
 const { imageSortBy, imagesCardView, imagesGroupBy, imagesScrollPaging } = storeToRefs(useMainStore())
 const items = ref<IImageItem[]>([])
@@ -179,6 +188,19 @@ const { loading, fetch } = initLazyQuery({
   document: imagesGQL,
   variables: () => ({ offset: (page.value - 1) * limit.value, limit: limit.value, query: effectiveQ.value, sortBy: effectiveIsGroupMode.value ? 'TAKEN_AT_DESC' : imageSortBy.value }),
 })
+
+const { moveLoading, moveItems, doMoveItems } = useMoveItems()
+const { t } = useI18n()
+async function onMoveClick() {
+  const q = moveItems(dataType, selectedIds.value, realAllChecked.value, getQuery())
+  if (q === undefined) return
+  const destDir = await promptModal<string>(DirectoryPickerModal, {
+    title: t('move_to_folder'),
+    modalId: 'move-images-picker',
+  })
+  if (typeof destDir !== 'string' || !destDir.trim()) return
+  doMoveItems(destDir.trim())
+}
 
 const sources = computed<ISource[]>(() => items.value.map((it: IImageItem) => ({
   src: getFileUrl(it.fileId), name: getFileName(it.path), duration: 0, size: it.size, path: it.path, type: dataType, data: it,


### PR DESCRIPTION
Adds a "Move to folder" action to the images bulk-selection toolbar:
- moveMediaItemsGQL mutation wrapper (companion backend PR plainhub/plain-app#360)
- useMoveItems hook emits media_items_actioned with action 'move' so list/sidebar/lightbox refresh
- ImagesView opens the existing DirectoryPickerModal to pick the target
- move_to_folder label added to all 17 locales